### PR TITLE
chore: Add complementary extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
   "extensionDependencies": [
     "ms-vscode.azure-account"
   ],
+  "extensionPack": [
+    "humao.rest-client",
+    "ms-graph.kiota",
+    "stoplight.spectral"
+  ],
   "enabledApiProposals": [
     "chatParticipant",
     "languageModels"


### PR DESCRIPTION
This extension requires the following extensions for use. However, users have to install them by themselves.

- [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
- [Microsoft Kiota](https://marketplace.visualstudio.com/items?itemName=ms-graph.kiota)
- [Spectral](https://marketplace.visualstudio.com/items?itemName=stoplight.spectral)

This PR includes the extensions above as its extension pack.

Please take a review.