### PR TITLE
fix: check status code for importing API spec

### DIFF
--- a/src/azure/ApiCenter/ApiCenterService.ts
+++ b/src/azure/ApiCenter/ApiCenterService.ts
@@ -159,16 +159,22 @@ export class ApiCenterService {
     };
     let response = await client.sendRequest(options);
 
-    const location = response.headers.get("Location");
+    if (response.status === 200) {
+      return true;
+    } else if (response.status === 202) {
+      const location = response.headers.get("Location");
 
-    if (!location) { return false; }
+      if (!location) { return false; }
 
-    options = {
-      method: "GET",
-      url: location,
-    };
+      options = {
+        method: "GET",
+        url: location,
+      };
 
-    return await this.sendRequestWithTimeout(client, options, 120000); // 2 minutes in milliseconds
+      return await this.sendRequestWithTimeout(client, options, 120000); // 2 minutes in milliseconds
+    } else {
+      return false;
+    }
   }
 
   public async exportSpecification(


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/One/_workitems/edit/27902122

Per doc of https://learn.microsoft.com/en-us/rest/api/resource-manager/apicenter/api-definitions/import-specification?view=rest-resource-manager-apicenter-2024-03-01&tabs=HTTP#response

The status code could be 200 or 202.
![image](https://github.com/microsoft/vscode-azureapicenter/assets/1050213/9db12b55-99fe-4fcb-b31e-243dd9b81918)
