### PR TITLE
Create a Microsoft Copilot plugin from an API in API Center

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
         "category": "Azure API Center"
       },
       {
+        "command": "azure-api-center.generate-api-plugin",
+        "title": "%azure-api-center.commands.generate-api-plugin.title%",
+        "category": "Azure API Center"
+      },
+      {
         "command": "azure-api-center.importOpenApiByFile",
         "title": "%azure-api-center.commands.importOpenApiByFile.title%",
         "category": "Azure API Center"
@@ -177,6 +182,10 @@
           "when": "view == apiCenterTreeView && viewItem == azureApiCenterApiVersionDefinitionTreeItem-openapi"
         },
         {
+          "command": "azure-api-center.generate-api-plugin",
+          "when": "view == apiCenterTreeView && viewItem == azureApiCenterApiVersionDefinitionTreeItem-openapi"
+        },
+        {
           "command": "azure-api-center.importOpenApiByFile",
           "when": "view == apiCenterTreeView && viewItem =~ /never/"
         },
@@ -249,6 +258,10 @@
         },
         {
           "command": "azure-api-center.generate-api-client",
+          "when": "never"
+        },
+        {
+          "command": "azure-api-center.generate-api-plugin",
           "when": "never"
         },
         {

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,7 @@
     "azure-api-center.commands.open-api-docs.title": "Open API Documentation",
     "azure-api-center.commands.open-postman.title": "Test in Postman",
     "azure-api-center.commands.generate-api-client.title": "Generate API Client",
+    "azure-api-center.commands.generate-api-plugin.title": "Create Microsoft Copilot plugin",
     "azure-api-center.commands.importOpenApiByFile.title": "Import OpenAPI from File",
     "azure-api-center.commands.importOpenApiByLink.title": "Import OpenAPI from Link",
     "azure-api-center.commands.exportApi.title": "Export API Specification Document",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,6 +94,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
     registerCommandWithTelemetry('azure-api-center.generate-api-client', generateApiLibrary);
 
+    registerCommandWithTelemetry('azure-api-center.generate-api-plugin', generateApiLibrary);
+
     registerCommandWithTelemetry('azure-api-center.generateHttpFile', GenerateHttpFile.generateHttpFile);
 
     registerCommandWithTelemetry('azure-api-center.registerApi', registerApi);


### PR DESCRIPTION
This PR adds the ability to create a plugin for Microsoft Copilot from an API in API Center leveraging Microsoft Kiota.

Note: This experience does require access to a pre-release build of the Microsoft Kiota VS Code extension.