### PR TITLE
feat: add telemetry for dataplane

### DIFF
--- a/package.json
+++ b/package.json
@@ -285,12 +285,12 @@
         },
         {
           "command": "azure-api-center.searchApi",
-          "when": "view == apiCenterTreeView && viewItem =~ /^azureApiCenterApis/",
+          "when": "(view == apiCenterTreeView || view == apiCenterWorkspace) && viewItem =~ /^azureApiCenterApis/ ",
           "group": "inline@0"
         },
         {
           "command": "azure-api-center.cleanupSearchResult",
-          "when": "view == apiCenterTreeView && viewItem == azureApiCenterApis-search",
+          "when": "(view == apiCenterTreeView || view == apiCenterWorkspace) && viewItem == azureApiCenterApis-search",
           "group": "inline@1"
         },
         {

--- a/src/commands/addDataPlaneApis.ts
+++ b/src/commands/addDataPlaneApis.ts
@@ -3,32 +3,43 @@
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as vscode from 'vscode';
 import { DataPlaneAccount } from "../azure/ApiCenter/ApiCenterDataPlaneAPIs";
+import { TelemetryClient } from "../common/telemetryClient";
+import { TelemetryEvent, TelemetryProperties } from "../common/telemetryEvent";
 import { ext } from "../extensionVariables";
 import { UiStrings } from "../uiStrings";
-export async function getDataPlaneApis(context: IActionContext): Promise<any | void> {
-    const endpointUrl = await vscode.window.showInputBox({ title: UiStrings.AddDataPlaneRuntimeUrl, ignoreFocusOut: true });
-    if (!endpointUrl) {
-        return;
-    }
-    const clientid = await vscode.window.showInputBox({ title: UiStrings.AddDataPlaneClientId, ignoreFocusOut: true });
-    if (!clientid) {
-        return;
-    }
-    const tenantid = await vscode.window.showInputBox({ title: UiStrings.AddDataPlaneTenantId, ignoreFocusOut: true });
-    if (!tenantid) {
-        return;
-    }
-
-    setAccountToExt(endpointUrl, clientid, tenantid);
-    ext.dataPlaneTreeItem.refresh(context);
-}
-export function setAccountToExt(domain: string, clientId: string, tenantId: string) {
-    function pushIfNotExist(array: DataPlaneAccount[], element: DataPlaneAccount) {
-        if (!array.some(item => item.domain === element.domain)) {
-            array.push(element);
-        } else {
-            vscode.window.showInformationMessage(UiStrings.DatplaneAlreadyAdded);
+export namespace ConnectDataPlaneApi {
+    export async function getDataPlaneApis(context: IActionContext): Promise<any | void> {
+        const endpointUrl = await vscode.window.showInputBox({ title: UiStrings.AddDataPlaneRuntimeUrl, ignoreFocusOut: true });
+        if (!endpointUrl) {
+            return;
         }
+        const clientid = await vscode.window.showInputBox({ title: UiStrings.AddDataPlaneClientId, ignoreFocusOut: true });
+        if (!clientid) {
+            return;
+        }
+        const tenantid = await vscode.window.showInputBox({ title: UiStrings.AddDataPlaneTenantId, ignoreFocusOut: true });
+        if (!tenantid) {
+            return;
+        }
+        ConnectDataPlaneApi.sendDataPlaneApiTelemetry(endpointUrl, clientid, tenantid);
+        ConnectDataPlaneApi.setAccountToExt(endpointUrl, clientid, tenantid);
+        ext.dataPlaneTreeItem.refresh(context);
     }
-    pushIfNotExist(ext.dataPlaneAccounts, { domain: domain, tenantId: tenantId, clientId: clientId });
+    export function sendDataPlaneApiTelemetry(runtimeUrl: string, clientId: string, tenantId: string) {
+        const properties: { [key: string]: string; } = {};
+        properties[TelemetryProperties.dataPlaneRuntimeUrl] = runtimeUrl;
+        properties[TelemetryProperties.dataPlaneTenantId] = tenantId;
+        properties[TelemetryProperties.dataPlaneClientId] = clientId;
+        TelemetryClient.sendEvent(TelemetryEvent.openUrlFromDataPlane, properties);
+    }
+    export function setAccountToExt(domain: string, clientId: string, tenantId: string) {
+        function pushIfNotExist(array: DataPlaneAccount[], element: DataPlaneAccount) {
+            if (!array.some(item => item.domain === element.domain)) {
+                array.push(element);
+            } else {
+                vscode.window.showInformationMessage(UiStrings.DatplaneAlreadyAdded);
+            }
+        }
+        pushIfNotExist(ext.dataPlaneAccounts, { domain: domain, tenantId: tenantId, clientId: clientId });
+    }
 }

--- a/src/commands/addDataPlaneApis.ts
+++ b/src/commands/addDataPlaneApis.ts
@@ -21,16 +21,16 @@ export namespace ConnectDataPlaneApi {
         if (!tenantid) {
             return;
         }
-        ConnectDataPlaneApi.sendDataPlaneApiTelemetry(endpointUrl, clientid, tenantid);
+        ConnectDataPlaneApi.sendDataPlaneApiTelemetry(endpointUrl, clientid, tenantid, TelemetryEvent.addDataPlaneApiFromInput);
         ConnectDataPlaneApi.setAccountToExt(endpointUrl, clientid, tenantid);
         ext.dataPlaneTreeItem.refresh(context);
     }
-    export function sendDataPlaneApiTelemetry(runtimeUrl: string, clientId: string, tenantId: string) {
+    export function sendDataPlaneApiTelemetry(runtimeUrl: string, clientId: string, tenantId: string, telemetryName: TelemetryEvent) {
         const properties: { [key: string]: string; } = {};
         properties[TelemetryProperties.dataPlaneRuntimeUrl] = runtimeUrl;
         properties[TelemetryProperties.dataPlaneTenantId] = tenantId;
         properties[TelemetryProperties.dataPlaneClientId] = clientId;
-        TelemetryClient.sendEvent(TelemetryEvent.addDataPlaneApiFromUrl, properties);
+        TelemetryClient.sendEvent(telemetryName, properties);
     }
     export function setAccountToExt(domain: string, clientId: string, tenantId: string) {
         function pushIfNotExist(array: DataPlaneAccount[], element: DataPlaneAccount) {

--- a/src/commands/addDataPlaneApis.ts
+++ b/src/commands/addDataPlaneApis.ts
@@ -8,6 +8,7 @@ import { TelemetryEvent, TelemetryProperties } from "../common/telemetryEvent";
 import { ext } from "../extensionVariables";
 import { UiStrings } from "../uiStrings";
 export namespace ConnectDataPlaneApi {
+    const dataPlaneApiFromDeepLink = "dataPlaneApiFromInput";
     export async function addDataPlaneApis(context: IActionContext): Promise<any | void> {
         const endpointUrl = await vscode.window.showInputBox({ title: UiStrings.AddDataPlaneRuntimeUrl, ignoreFocusOut: true });
         if (!endpointUrl) {
@@ -21,16 +22,17 @@ export namespace ConnectDataPlaneApi {
         if (!tenantid) {
             return;
         }
-        ConnectDataPlaneApi.sendDataPlaneApiTelemetry(endpointUrl, clientid, tenantid, TelemetryEvent.addDataPlaneApiFromInput);
+        ConnectDataPlaneApi.sendDataPlaneApiTelemetry(endpointUrl, clientid, tenantid, dataPlaneApiFromDeepLink);
         ConnectDataPlaneApi.setAccountToExt(endpointUrl, clientid, tenantid);
         ext.dataPlaneTreeItem.refresh(context);
     }
-    export function sendDataPlaneApiTelemetry(runtimeUrl: string, clientId: string, tenantId: string, telemetryName: TelemetryEvent) {
+    export function sendDataPlaneApiTelemetry(runtimeUrl: string, clientId: string, tenantId: string, fromType: string) {
         const properties: { [key: string]: string; } = {};
         properties[TelemetryProperties.dataPlaneRuntimeUrl] = runtimeUrl;
         properties[TelemetryProperties.dataPlaneTenantId] = tenantId;
         properties[TelemetryProperties.dataPlaneClientId] = clientId;
-        TelemetryClient.sendEvent(telemetryName, properties);
+        properties[TelemetryProperties.dataPlaneAddApiSource] = fromType;
+        TelemetryClient.sendEvent(TelemetryEvent.addDataPlaneInstance, properties);
     }
     export function setAccountToExt(domain: string, clientId: string, tenantId: string) {
         function pushIfNotExist(array: DataPlaneAccount[], element: DataPlaneAccount) {

--- a/src/commands/addDataPlaneApis.ts
+++ b/src/commands/addDataPlaneApis.ts
@@ -8,7 +8,7 @@ import { TelemetryEvent, TelemetryProperties } from "../common/telemetryEvent";
 import { ext } from "../extensionVariables";
 import { UiStrings } from "../uiStrings";
 export namespace ConnectDataPlaneApi {
-    const dataPlaneApiFromDeepLink = "dataPlaneApiFromInput";
+    const dataPlaneApiFromInput = "dataPlaneApiFromInput";
     export async function addDataPlaneApis(context: IActionContext): Promise<any | void> {
         const endpointUrl = await vscode.window.showInputBox({ title: UiStrings.AddDataPlaneRuntimeUrl, ignoreFocusOut: true });
         if (!endpointUrl) {
@@ -22,7 +22,7 @@ export namespace ConnectDataPlaneApi {
         if (!tenantid) {
             return;
         }
-        ConnectDataPlaneApi.sendDataPlaneApiTelemetry(endpointUrl, clientid, tenantid, dataPlaneApiFromDeepLink);
+        ConnectDataPlaneApi.sendDataPlaneApiTelemetry(endpointUrl, clientid, tenantid, dataPlaneApiFromInput);
         ConnectDataPlaneApi.setAccountToExt(endpointUrl, clientid, tenantid);
         ext.dataPlaneTreeItem.refresh(context);
     }

--- a/src/commands/addDataPlaneApis.ts
+++ b/src/commands/addDataPlaneApis.ts
@@ -4,7 +4,7 @@ import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as vscode from 'vscode';
 import { DataPlaneAccount } from "../azure/ApiCenter/ApiCenterDataPlaneAPIs";
 import { TelemetryClient } from "../common/telemetryClient";
-import { TelemetryEvent, TelemetryProperties } from "../common/telemetryEvent";
+import { DataPlaneApiFromType, TelemetryEvent, TelemetryProperties } from "../common/telemetryEvent";
 import { ext } from "../extensionVariables";
 import { UiStrings } from "../uiStrings";
 export namespace ConnectDataPlaneApi {
@@ -22,11 +22,11 @@ export namespace ConnectDataPlaneApi {
         if (!tenantid) {
             return;
         }
-        ConnectDataPlaneApi.sendDataPlaneApiTelemetry(endpointUrl, clientid, tenantid, dataPlaneApiFromInput);
+        ConnectDataPlaneApi.sendDataPlaneApiTelemetry(endpointUrl, clientid, tenantid, DataPlaneApiFromType.dataPlaneApiAddFromInput);
         ConnectDataPlaneApi.setAccountToExt(endpointUrl, clientid, tenantid);
         ext.dataPlaneTreeItem.refresh(context);
     }
-    export function sendDataPlaneApiTelemetry(runtimeUrl: string, clientId: string, tenantId: string, fromType: string) {
+    export function sendDataPlaneApiTelemetry(runtimeUrl: string, clientId: string, tenantId: string, fromType: DataPlaneApiFromType) {
         const properties: { [key: string]: string; } = {};
         properties[TelemetryProperties.dataPlaneRuntimeUrl] = runtimeUrl;
         properties[TelemetryProperties.dataPlaneTenantId] = tenantId;

--- a/src/commands/addDataPlaneApis.ts
+++ b/src/commands/addDataPlaneApis.ts
@@ -30,7 +30,7 @@ export namespace ConnectDataPlaneApi {
         properties[TelemetryProperties.dataPlaneRuntimeUrl] = runtimeUrl;
         properties[TelemetryProperties.dataPlaneTenantId] = tenantId;
         properties[TelemetryProperties.dataPlaneClientId] = clientId;
-        TelemetryClient.sendEvent(TelemetryEvent.openUrlFromDataPlane, properties);
+        TelemetryClient.sendEvent(TelemetryEvent.addDataPlaneApiFromUrl, properties);
     }
     export function setAccountToExt(domain: string, clientId: string, tenantId: string) {
         function pushIfNotExist(array: DataPlaneAccount[], element: DataPlaneAccount) {

--- a/src/commands/addDataPlaneApis.ts
+++ b/src/commands/addDataPlaneApis.ts
@@ -8,7 +8,7 @@ import { TelemetryEvent, TelemetryProperties } from "../common/telemetryEvent";
 import { ext } from "../extensionVariables";
 import { UiStrings } from "../uiStrings";
 export namespace ConnectDataPlaneApi {
-    export async function getDataPlaneApis(context: IActionContext): Promise<any | void> {
+    export async function addDataPlaneApis(context: IActionContext): Promise<any | void> {
         const endpointUrl = await vscode.window.showInputBox({ title: UiStrings.AddDataPlaneRuntimeUrl, ignoreFocusOut: true });
         if (!endpointUrl) {
             return;

--- a/src/commands/handleUri.ts
+++ b/src/commands/handleUri.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import * as vscode from 'vscode';
+import { TelemetryEvent } from "../common/telemetryEvent";
 import { ConnectDataPlaneApi } from "./addDataPlaneApis";
 export async function handleUri(uri: vscode.Uri) {
     const queryParams = new URLSearchParams(uri.query);
     let tenantId = queryParams.get('tenantId') as string;
     let clientId = queryParams.get('clientId') as string;
     let runtimeUrl = queryParams.get('runtimeUrl') as string;
-    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId);
+    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId, TelemetryEvent.addDataPlaneApiFromDeepLink);
     ConnectDataPlaneApi.setAccountToExt(runtimeUrl, clientId, tenantId);
     vscode.commands.executeCommand('azure-api-center.apiCenterWorkspace.refresh');
 };

--- a/src/commands/handleUri.ts
+++ b/src/commands/handleUri.ts
@@ -3,12 +3,12 @@
 import * as vscode from 'vscode';
 import { ConnectDataPlaneApi } from "./addDataPlaneApis";
 export async function handleUri(uri: vscode.Uri) {
-    const dataPlaneApiFromInput: string = "dataPlaneApiFromInput";
+    const dataPlaneApiFromDeepLink: string = "dataPlaneApiFromDeepLink";
     const queryParams = new URLSearchParams(uri.query);
     let tenantId = queryParams.get('tenantId') as string;
     let clientId = queryParams.get('clientId') as string;
     let runtimeUrl = queryParams.get('runtimeUrl') as string;
-    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId, dataPlaneApiFromInput);
+    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId, dataPlaneApiFromDeepLink);
     ConnectDataPlaneApi.setAccountToExt(runtimeUrl, clientId, tenantId);
     vscode.commands.executeCommand('azure-api-center.apiCenterWorkspace.refresh');
 };

--- a/src/commands/handleUri.ts
+++ b/src/commands/handleUri.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import * as vscode from 'vscode';
-import { TelemetryEvent } from "../common/telemetryEvent";
 import { ConnectDataPlaneApi } from "./addDataPlaneApis";
 export async function handleUri(uri: vscode.Uri) {
+    const dataPlaneApiFromInput: string = "dataPlaneApiFromInput";
     const queryParams = new URLSearchParams(uri.query);
     let tenantId = queryParams.get('tenantId') as string;
     let clientId = queryParams.get('clientId') as string;
     let runtimeUrl = queryParams.get('runtimeUrl') as string;
-    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId, TelemetryEvent.addDataPlaneApiFromDeepLink);
+    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId, dataPlaneApiFromInput);
     ConnectDataPlaneApi.setAccountToExt(runtimeUrl, clientId, tenantId);
     vscode.commands.executeCommand('azure-api-center.apiCenterWorkspace.refresh');
 };

--- a/src/commands/handleUri.ts
+++ b/src/commands/handleUri.ts
@@ -1,19 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import * as vscode from 'vscode';
-import { TelemetryClient } from "../common/telemetryClient";
-import { TelemetryEvent, TelemetryProperties } from "../common/telemetryEvent";
-import { setAccountToExt } from "./addDataPlaneApis";
+import { ConnectDataPlaneApi } from "./addDataPlaneApis";
 export async function handleUri(uri: vscode.Uri) {
     const queryParams = new URLSearchParams(uri.query);
     let tenantId = queryParams.get('tenantId') as string;
     let clientId = queryParams.get('clientId') as string;
     let runtimeUrl = queryParams.get('runtimeUrl') as string;
-    setAccountToExt(runtimeUrl, clientId, tenantId);
-    const properties: { [key: string]: string; } = {};
-    properties[TelemetryProperties.dataPlaneRuntimeUrl] = runtimeUrl;
-    properties[TelemetryProperties.dataPlaneTenantId] = tenantId;
-    properties[TelemetryProperties.dataPlaneClientId] = clientId;
-    TelemetryClient.sendEvent(TelemetryEvent.openUrlFromDataPlane, properties);
+    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId)
+    ConnectDataPlaneApi.setAccountToExt(runtimeUrl, clientId, tenantId);
     vscode.commands.executeCommand('azure-api-center.apiCenterWorkspace.refresh');
 };

--- a/src/commands/handleUri.ts
+++ b/src/commands/handleUri.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import * as vscode from 'vscode';
+import { TelemetryClient } from "../common/telemetryClient";
+import { TelemetryEvent, TelemetryProperties } from "../common/telemetryEvent";
 import { setAccountToExt } from "./addDataPlaneApis";
 export async function handleUri(uri: vscode.Uri) {
     const queryParams = new URLSearchParams(uri.query);
@@ -8,5 +10,10 @@ export async function handleUri(uri: vscode.Uri) {
     let clientId = queryParams.get('clientId') as string;
     let runtimeUrl = queryParams.get('runtimeUrl') as string;
     setAccountToExt(runtimeUrl, clientId, tenantId);
+    const properties: { [key: string]: string; } = {};
+    properties[TelemetryProperties.dataPlaneRuntimeUrl] = runtimeUrl;
+    properties[TelemetryProperties.dataPlaneTenantId] = tenantId;
+    properties[TelemetryProperties.dataPlaneClientId] = clientId;
+    TelemetryClient.sendEvent(TelemetryEvent.openUrlFromDataPlane, properties);
     vscode.commands.executeCommand('azure-api-center.apiCenterWorkspace.refresh');
 };

--- a/src/commands/handleUri.ts
+++ b/src/commands/handleUri.ts
@@ -7,7 +7,7 @@ export async function handleUri(uri: vscode.Uri) {
     let tenantId = queryParams.get('tenantId') as string;
     let clientId = queryParams.get('clientId') as string;
     let runtimeUrl = queryParams.get('runtimeUrl') as string;
-    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId)
+    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId);
     ConnectDataPlaneApi.setAccountToExt(runtimeUrl, clientId, tenantId);
     vscode.commands.executeCommand('azure-api-center.apiCenterWorkspace.refresh');
 };

--- a/src/commands/handleUri.ts
+++ b/src/commands/handleUri.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import * as vscode from 'vscode';
+import { DataPlaneApiFromType } from "../common/telemetryEvent";
 import { ConnectDataPlaneApi } from "./addDataPlaneApis";
 export async function handleUri(uri: vscode.Uri) {
-    const dataPlaneApiFromDeepLink: string = "dataPlaneApiFromDeepLink";
     const queryParams = new URLSearchParams(uri.query);
     let tenantId = queryParams.get('tenantId') as string;
     let clientId = queryParams.get('clientId') as string;
     let runtimeUrl = queryParams.get('runtimeUrl') as string;
-    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId, dataPlaneApiFromDeepLink);
+    ConnectDataPlaneApi.sendDataPlaneApiTelemetry(runtimeUrl, clientId, tenantId, DataPlaneApiFromType.dataPlaneApiAddFromDeepLink);
     ConnectDataPlaneApi.setAccountToExt(runtimeUrl, clientId, tenantId);
     vscode.commands.executeCommand('azure-api-center.apiCenterWorkspace.refresh');
 };

--- a/src/common/telemetryEvent.ts
+++ b/src/common/telemetryEvent.ts
@@ -25,3 +25,9 @@ export enum ErrorProperties {
     errorType = "errorType",
     errorMessage = "errorMessage",
 };
+
+
+export enum DataPlaneApiFromType {
+    dataPlaneApiAddFromInput = "dataPlaneApiAddFromInput",
+    dataPlaneApiAddFromDeepLink = "dataPlaneApiAddFromDeepLink",
+};

--- a/src/common/telemetryEvent.ts
+++ b/src/common/telemetryEvent.ts
@@ -6,7 +6,7 @@ export enum TelemetryEvent {
     registerApiSelectOption = "registerApi.selectOption",
     setApiRulesetSelectOption = "setApiRuleset.selectOption",
     treeviewListDataPlane = "treeview.listDataPlane",
-    openUrlFromDataPlane = "openUrl.dataPlaneApi",
+    addDataPlaneApiFromUrl = "openUrl.addDataPlaneApi",
 }
 
 export enum TelemetryProperties {

--- a/src/common/telemetryEvent.ts
+++ b/src/common/telemetryEvent.ts
@@ -5,6 +5,7 @@ export enum TelemetryEvent {
     treeviewListApiCenters = "treeview.listApiCenters",
     registerApiSelectOption = "registerApi.selectOption",
     setApiRulesetSelectOption = "setApiRuleset.selectOption",
+    treeviewListDataPlane = "treeview.listDataPlane",
 }
 
 export enum TelemetryProperties {
@@ -13,6 +14,7 @@ export enum TelemetryProperties {
     option = 'option',
     subscriptionId = 'subscriptionId',
     resourceName = 'resourceName',
+    dataPlaneRuntimeUrl = 'dataPlaneRuntimeUrl',
 };
 
 export enum ErrorProperties {

--- a/src/common/telemetryEvent.ts
+++ b/src/common/telemetryEvent.ts
@@ -5,8 +5,9 @@ export enum TelemetryEvent {
     treeviewListApiCenters = "treeview.listApiCenters",
     registerApiSelectOption = "registerApi.selectOption",
     setApiRulesetSelectOption = "setApiRuleset.selectOption",
-    treeviewListDataPlane = "treeview.listDataPlane",
-    addDataPlaneApiFromUrl = "openUrl.addDataPlaneApi",
+    treeviewListDataPlane = "treeview.listDataPlaneServer",
+    addDataPlaneApiFromDeepLink = "openDeepLink.addDataPlaneApi",
+    addDataPlaneApiFromInput = "addDataPlaneApi.addDataPlaneApi"
 }
 
 export enum TelemetryProperties {

--- a/src/common/telemetryEvent.ts
+++ b/src/common/telemetryEvent.ts
@@ -6,8 +6,7 @@ export enum TelemetryEvent {
     registerApiSelectOption = "registerApi.selectOption",
     setApiRulesetSelectOption = "setApiRuleset.selectOption",
     treeviewListDataPlane = "treeview.listDataPlaneServer",
-    addDataPlaneApiFromDeepLink = "openDeepLink.addDataPlaneApi",
-    addDataPlaneApiFromInput = "addDataPlaneApi.addDataPlaneApi"
+    addDataPlaneInstance = "dataPlane.addApiInstance"
 }
 
 export enum TelemetryProperties {
@@ -19,6 +18,7 @@ export enum TelemetryProperties {
     dataPlaneRuntimeUrl = 'dataPlaneRuntimeUrl',
     dataPlaneTenantId = "dataPlaneTenantId",
     dataPlaneClientId = "dataPlaneClientId",
+    dataPlaneAddApiSource = "dataPlaneApiAddSource",
 };
 
 export enum ErrorProperties {

--- a/src/common/telemetryEvent.ts
+++ b/src/common/telemetryEvent.ts
@@ -15,6 +15,7 @@ export enum TelemetryProperties {
     subscriptionId = 'subscriptionId',
     resourceName = 'resourceName',
     dataPlaneRuntimeUrl = 'dataPlaneRuntimeUrl',
+    dataPlaneTenant = "dataPlaneTenant"
 };
 
 export enum ErrorProperties {

--- a/src/common/telemetryEvent.ts
+++ b/src/common/telemetryEvent.ts
@@ -6,6 +6,7 @@ export enum TelemetryEvent {
     registerApiSelectOption = "registerApi.selectOption",
     setApiRulesetSelectOption = "setApiRuleset.selectOption",
     treeviewListDataPlane = "treeview.listDataPlane",
+    openUrlFromDataPlane = "openUrl.dataPlaneApi",
 }
 
 export enum TelemetryProperties {
@@ -15,7 +16,8 @@ export enum TelemetryProperties {
     subscriptionId = 'subscriptionId',
     resourceName = 'resourceName',
     dataPlaneRuntimeUrl = 'dataPlaneRuntimeUrl',
-    dataPlaneTenant = "dataPlaneTenant"
+    dataPlaneTenantId = "dataPlaneTenantId",
+    dataPlaneClientId = "dataPlaneClientId",
 };
 
 export enum ErrorProperties {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import { AzExtTreeDataProvider, AzExtTreeItem, CommandCallback, IActionContext, 
 import { AzureAccount } from "./azure/azureLogin/azureAccount";
 import { AzureSessionProviderHelper } from "./azure/azureLogin/azureSessionProvider";
 import { AzureDataSessionProviderHelper } from "./azure/azureLogin/dataSessionProvider";
-import { getDataPlaneApis } from "./commands/addDataPlaneApis";
+import { ConnectDataPlaneApi } from "./commands/addDataPlaneApis";
 import { cleanupSearchResult } from './commands/cleanUpSearch';
 import { detectBreakingChange } from './commands/detectBreakingChange';
 import { showOpenApi } from './commands/editOpenApi';
@@ -128,7 +128,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerCommandWithTelemetry('azure-api-center.openUrl', openUrlFromTreeNode);
     registerCommandWithTelemetry('azure-api-center.apiCenterWorkspace.signInToDataPlane', SignInToDataPlane);
     registerCommandWithTelemetry('azure-api-center.apiCenterWorkspace.refresh', async (context: IActionContext) => ext.dataPlaneTreeItem.refresh(context));
-    registerCommandWithTelemetry('azure-api-center.apiCenterWorkspace.addApis', getDataPlaneApis);
+    registerCommandWithTelemetry('azure-api-center.apiCenterWorkspace.addApis', ConnectDataPlaneApi.getDataPlaneApis);
     registerCommandWithTelemetry('azure-api-center.apiCenterWorkspace.collapse', () => {
         vscode.commands.executeCommand('workbench.actions.treeView.apiCenterWorkspace.collapseAll');
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,7 +128,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerCommandWithTelemetry('azure-api-center.openUrl', openUrlFromTreeNode);
     registerCommandWithTelemetry('azure-api-center.apiCenterWorkspace.signInToDataPlane', SignInToDataPlane);
     registerCommandWithTelemetry('azure-api-center.apiCenterWorkspace.refresh', async (context: IActionContext) => ext.dataPlaneTreeItem.refresh(context));
-    registerCommandWithTelemetry('azure-api-center.apiCenterWorkspace.addApis', ConnectDataPlaneApi.getDataPlaneApis);
+    registerCommandWithTelemetry('azure-api-center.apiCenterWorkspace.addApis', ConnectDataPlaneApi.addDataPlaneApis);
     registerCommandWithTelemetry('azure-api-center.apiCenterWorkspace.collapse', () => {
         vscode.commands.executeCommand('workbench.actions.treeView.apiCenterWorkspace.collapseAll');
     });

--- a/src/test/unit/commands/addDataPlaneApi.test.ts
+++ b/src/test/unit/commands/addDataPlaneApi.test.ts
@@ -4,6 +4,7 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { ConnectDataPlaneApi } from '../../../commands/addDataPlaneApis';
 import { TelemetryClient } from "../../../common/telemetryClient";
+import { DataPlaneApiFromType } from "../../../common/telemetryEvent";
 describe('getDataPlaneApis test happy path', () => {
     let sandbox = null as any;
     before(() => {
@@ -17,12 +18,12 @@ describe('getDataPlaneApis test happy path', () => {
     });
     it("sendDataPlaneApiTelemetry happy path", async () => {
         let sendEventStub = sandbox.stub(TelemetryClient, "sendEvent").returns();
-        ConnectDataPlaneApi.sendDataPlaneApiTelemetry("fakeRuntimeUrl", "fakeClientId", "fakeTenantId", "dataPlaneApiFromInput");
+        ConnectDataPlaneApi.sendDataPlaneApiTelemetry("fakeRuntimeUrl", "fakeClientId", "fakeTenantId", DataPlaneApiFromType.dataPlaneApiAddFromInput);
         sandbox.assert.calledOnce(sendEventStub);
         assert.equal(sendEventStub.getCall(0).args[0], "dataPlane.addApiInstance");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneRuntimeUrl, "fakeRuntimeUrl");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneTenantId, "fakeTenantId");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneClientId, "fakeClientId");
-        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneApiAddSource, "dataPlaneApiFromInput");
+        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneApiAddSource, "dataPlaneApiAddFromInput");
     });
 });

--- a/src/test/unit/commands/addDataPlaneApi.test.ts
+++ b/src/test/unit/commands/addDataPlaneApi.test.ts
@@ -19,7 +19,7 @@ describe('getDataPlaneApis test happy path', () => {
         let sendEventStub = sandbox.stub(TelemetryClient, "sendEvent").returns();
         ConnectDataPlaneApi.sendDataPlaneApiTelemetry("fakeRuntimeUrl", "fakeClientId", "fakeTenantId");
         sandbox.assert.calledOnce(sendEventStub);
-        assert.equal(sendEventStub.getCall(0).args[0], "openUrl.dataPlaneApi");
+        assert.equal(sendEventStub.getCall(0).args[0], "openUrl.addDataPlaneApi");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneRuntimeUrl, "fakeRuntimeUrl");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneTenantId, "fakeTenantId");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneClientId, "fakeClientId");

--- a/src/test/unit/commands/addDataPlaneApi.test.ts
+++ b/src/test/unit/commands/addDataPlaneApi.test.ts
@@ -4,6 +4,7 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { ConnectDataPlaneApi } from '../../../commands/addDataPlaneApis';
 import { TelemetryClient } from "../../../common/telemetryClient";
+import { TelemetryEvent } from "../../../common/telemetryEvent";
 describe('getDataPlaneApis test happy path', () => {
     let sandbox = null as any;
     before(() => {
@@ -17,9 +18,9 @@ describe('getDataPlaneApis test happy path', () => {
     });
     it("sendDataPlaneApiTelemetry happy path", async () => {
         let sendEventStub = sandbox.stub(TelemetryClient, "sendEvent").returns();
-        ConnectDataPlaneApi.sendDataPlaneApiTelemetry("fakeRuntimeUrl", "fakeClientId", "fakeTenantId");
+        ConnectDataPlaneApi.sendDataPlaneApiTelemetry("fakeRuntimeUrl", "fakeClientId", "fakeTenantId", TelemetryEvent.addDataPlaneApiFromInput);
         sandbox.assert.calledOnce(sendEventStub);
-        assert.equal(sendEventStub.getCall(0).args[0], "openUrl.addDataPlaneApi");
+        assert.equal(sendEventStub.getCall(0).args[0], "addDataPlaneApi.addDataPlaneApi");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneRuntimeUrl, "fakeRuntimeUrl");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneTenantId, "fakeTenantId");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneClientId, "fakeClientId");

--- a/src/test/unit/commands/addDataPlaneApi.test.ts
+++ b/src/test/unit/commands/addDataPlaneApi.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { ConnectDataPlaneApi } from '../../../commands/addDataPlaneApis';
+import { TelemetryClient } from "../../../common/telemetryClient";
+describe('getDataPlaneApis test happy path', () => {
+    let sandbox = null as any;
+    before(() => {
+        sandbox = sinon.createSandbox();
+    });
+    beforeEach(() => {
+        sinon.restore();
+    });
+    afterEach(() => {
+        sandbox.restore();
+    });
+    it("sendDataPlaneApiTelemetry happy path", async () => {
+        let sendEventStub = sandbox.stub(TelemetryClient, "sendEvent").returns();
+        ConnectDataPlaneApi.sendDataPlaneApiTelemetry("fakeRuntimeUrl", "fakeClientId", "fakeTenantId");
+        sandbox.assert.calledOnce(sendEventStub);
+        assert.equal(sendEventStub.getCall(0).args[0], "openUrl.dataPlaneApi");
+        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneRuntimeUrl, "fakeRuntimeUrl");
+        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneTenantId, "fakeTenantId");
+        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneClientId, "fakeClientId");
+    });
+});

--- a/src/test/unit/commands/addDataPlaneApi.test.ts
+++ b/src/test/unit/commands/addDataPlaneApi.test.ts
@@ -4,7 +4,6 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { ConnectDataPlaneApi } from '../../../commands/addDataPlaneApis';
 import { TelemetryClient } from "../../../common/telemetryClient";
-import { TelemetryEvent } from "../../../common/telemetryEvent";
 describe('getDataPlaneApis test happy path', () => {
     let sandbox = null as any;
     before(() => {
@@ -18,11 +17,12 @@ describe('getDataPlaneApis test happy path', () => {
     });
     it("sendDataPlaneApiTelemetry happy path", async () => {
         let sendEventStub = sandbox.stub(TelemetryClient, "sendEvent").returns();
-        ConnectDataPlaneApi.sendDataPlaneApiTelemetry("fakeRuntimeUrl", "fakeClientId", "fakeTenantId", TelemetryEvent.addDataPlaneApiFromInput);
+        ConnectDataPlaneApi.sendDataPlaneApiTelemetry("fakeRuntimeUrl", "fakeClientId", "fakeTenantId", "dataPlaneApiFromInput");
         sandbox.assert.calledOnce(sendEventStub);
-        assert.equal(sendEventStub.getCall(0).args[0], "addDataPlaneApi.addDataPlaneApi");
+        assert.equal(sendEventStub.getCall(0).args[0], "dataPlane.addApiInstance");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneRuntimeUrl, "fakeRuntimeUrl");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneTenantId, "fakeTenantId");
         assert.equal(sendEventStub.getCall(0).args[1].dataPlaneClientId, "fakeClientId");
+        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneApiAddSource, "dataPlaneApiFromInput");
     });
 });

--- a/src/test/unit/commands/handleUri.test.ts
+++ b/src/test/unit/commands/handleUri.test.ts
@@ -3,9 +3,8 @@
 import * as assert from 'assert';
 import * as sinon from "sinon";
 import * as vscode from "vscode";
-import * as addDataPlaneApis from '../../../commands/addDataPlaneApis';
+import { ConnectDataPlaneApi } from '../../../commands/addDataPlaneApis';
 import { handleUri } from "../../../commands/handleUri";
-import { TelemetryClient } from "../../../common/telemetryClient";
 describe('handleUri test happy path', () => {
     let sandbox = null as any;
     before(() => {
@@ -17,18 +16,14 @@ describe('handleUri test happy path', () => {
     it('handleUri happy path', async () => {
         const fakeUrl = 'vscode-insiders://apidev.azure-api-center?clientId=fakeClientId&tenantId=fakeTenantId&runtimeUrl=fakeRuntimeUrl';
         const url = vscode.Uri.parse(fakeUrl);
-        const sendEventStub = sandbox.stub(TelemetryClient, "sendEvent").returns();
-        const stubSetAccountToExt = sandbox.stub(addDataPlaneApis, "setAccountToExt").returns();
+        let stubTelemetryEvent = sandbox.stub(ConnectDataPlaneApi, "sendDataPlaneApiTelemetry").returns();
+        let stubSetAccountToExt = sandbox.stub(ConnectDataPlaneApi, "setAccountToExt").returns();
         sandbox.stub(vscode.commands, 'executeCommand').resolves();
         await handleUri(url);
         sandbox.assert.calledOnce(stubSetAccountToExt);
         assert.equal(stubSetAccountToExt.getCall(0).args[0], 'fakeRuntimeUrl');
         assert.equal(stubSetAccountToExt.getCall(0).args[1], 'fakeClientId');
         assert.equal(stubSetAccountToExt.getCall(0).args[2], 'fakeTenantId');
-        sandbox.assert.calledOnce(sendEventStub);
-        assert.equal(sendEventStub.getCall(0).args[0], "openUrl.dataPlaneApi");
-        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneRuntimeUrl, "fakeRuntimeUrl");
-        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneTenantId, "fakeTenantId");
-        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneClientId, "fakeClientId");
+        sandbox.assert.calledOnce(stubTelemetryEvent);
     });
 });

--- a/src/test/unit/commands/handleUri.test.ts
+++ b/src/test/unit/commands/handleUri.test.ts
@@ -25,5 +25,6 @@ describe('handleUri test happy path', () => {
         assert.equal(stubSetAccountToExt.getCall(0).args[1], 'fakeClientId');
         assert.equal(stubSetAccountToExt.getCall(0).args[2], 'fakeTenantId');
         sandbox.assert.calledOnce(stubTelemetryEvent);
+        assert.equal(stubTelemetryEvent.getCall(0).args[3], 'openDeepLink.addDataPlaneApi');
     });
 });

--- a/src/test/unit/commands/handleUri.test.ts
+++ b/src/test/unit/commands/handleUri.test.ts
@@ -5,6 +5,7 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 import * as addDataPlaneApis from '../../../commands/addDataPlaneApis';
 import { handleUri } from "../../../commands/handleUri";
+import { TelemetryClient } from "../../../common/telemetryClient";
 describe('handleUri test happy path', () => {
     let sandbox = null as any;
     before(() => {
@@ -16,6 +17,7 @@ describe('handleUri test happy path', () => {
     it('handleUri happy path', async () => {
         const fakeUrl = 'vscode-insiders://apidev.azure-api-center?clientId=fakeClientId&tenantId=fakeTenantId&runtimeUrl=fakeRuntimeUrl';
         const url = vscode.Uri.parse(fakeUrl);
+        const sendEventStub = sandbox.stub(TelemetryClient, "sendEvent").returns();
         const stubSetAccountToExt = sandbox.stub(addDataPlaneApis, "setAccountToExt").returns();
         sandbox.stub(vscode.commands, 'executeCommand').resolves();
         await handleUri(url);
@@ -23,5 +25,10 @@ describe('handleUri test happy path', () => {
         assert.equal(stubSetAccountToExt.getCall(0).args[0], 'fakeRuntimeUrl');
         assert.equal(stubSetAccountToExt.getCall(0).args[1], 'fakeClientId');
         assert.equal(stubSetAccountToExt.getCall(0).args[2], 'fakeTenantId');
+        sandbox.assert.calledOnce(sendEventStub);
+        assert.equal(sendEventStub.getCall(0).args[0], "openUrl.dataPlaneApi");
+        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneRuntimeUrl, "fakeRuntimeUrl");
+        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneTenantId, "fakeTenantId");
+        assert.equal(sendEventStub.getCall(0).args[1].dataPlaneClientId, "fakeClientId");
     });
 });

--- a/src/test/unit/commands/handleUri.test.ts
+++ b/src/test/unit/commands/handleUri.test.ts
@@ -25,6 +25,6 @@ describe('handleUri test happy path', () => {
         assert.equal(stubSetAccountToExt.getCall(0).args[1], 'fakeClientId');
         assert.equal(stubSetAccountToExt.getCall(0).args[2], 'fakeTenantId');
         sandbox.assert.calledOnce(stubTelemetryEvent);
-        assert.equal(stubTelemetryEvent.getCall(0).args[3], 'dataPlaneApiFromInput');
+        assert.equal(stubTelemetryEvent.getCall(0).args[3], 'dataPlaneApiAddFromDeepLink');
     });
 });

--- a/src/test/unit/commands/handleUri.test.ts
+++ b/src/test/unit/commands/handleUri.test.ts
@@ -25,6 +25,6 @@ describe('handleUri test happy path', () => {
         assert.equal(stubSetAccountToExt.getCall(0).args[1], 'fakeClientId');
         assert.equal(stubSetAccountToExt.getCall(0).args[2], 'fakeTenantId');
         sandbox.assert.calledOnce(stubTelemetryEvent);
-        assert.equal(stubTelemetryEvent.getCall(0).args[3], 'openDeepLink.addDataPlaneApi');
+        assert.equal(stubTelemetryEvent.getCall(0).args[3], 'dataPlaneApiFromInput');
     });
 });

--- a/src/test/unit/tree/dataPlaneAccountTreeItem.test.ts
+++ b/src/test/unit/tree/dataPlaneAccountTreeItem.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { IActionContext, IAzExtOutputChannel, ISubscriptionContext, registerUIExtensionVariables } from "@microsoft/vscode-azext-utils";
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { AzureAuthenticationSession, AzureDataSessionProvider, SignInStatus } from "../../../azure/azureLogin/authTypes";
+import { AzureAuth } from "../../../azure/azureLogin/azureAuth";
+import { AzureDataSessionProviderHelper } from "../../../azure/azureLogin/dataSessionProvider";
+import { TelemetryClient } from "../../../common/telemetryClient";
+import { ext } from "../../../extensionVariables";
+import { ApiServerItem, DataPlanAccountManagerTreeItem } from "../../../tree/DataPlaneAccount";
+describe("ApiServerItem treeItem test case", () => {
+    let sandbox = null as any;
+    let sessionProvider: AzureDataSessionProvider;
+    let subContext: ISubscriptionContext;
+    before(() => {
+        sandbox = sinon.createSandbox();
+    });
+    beforeEach(() => {
+        const credentials = AzureAuth.getDataPlaneCredential("fakeClientId", "fakeTenantId");
+        const environment = AzureAuth.getEnvironment();
+        function gloablStateKeys(): readonly string[] {
+            return ["PrereleaseState.Version"];
+        }
+        function globalStateGet(key: string): string {
+            return "0.0.0";
+        }
+        function globalStateUpdate(key: string, value: any): any { }
+        const mockGlobalState: vscode.Memento = {
+            keys: gloablStateKeys,
+            get: globalStateGet,
+            update: globalStateUpdate,
+        };
+        ext.context = {
+            subscriptions: [],
+            globalState: mockGlobalState,
+            extension: {
+                packageJSON: {
+                    name: "azure-api-center",
+                    publisher: "apidev",
+                    displayName: "Azure API Center",
+                    description: "Build, discover, and consume APIs.",
+                    version: "1.0.0",
+                    bugsUrl: "https://fake_url",
+                    aiKey: "fake_Aikey"
+                }
+            }
+        } as unknown as vscode.ExtensionContext;
+        ext.outputChannel = {
+            appendLog: () => { },
+            show: () => { },
+            info: () => { },
+        } as unknown as IAzExtOutputChannel;
+        registerUIExtensionVariables(ext);
+        sessionProvider = {
+            signIn: async () => { },
+            signInStatus: SignInStatus.Initializing,
+            dispose: () => { },
+            getAuthSession: async () => {
+                return { succeeded: false, error: "test failed" };
+            },
+            signInStatusChangeEvent: new vscode.EventEmitter<SignInStatus>().event,
+        };
+        subContext = {
+            credentials,
+            subscriptionDisplayName: "",
+            subscriptionId: "",
+            subscriptionPath: "fake_test_domain",
+            tenantId: "fake_tenant_id",
+            userId: "fake_client_id",
+            environment,
+            isCustomCloud: environment.name === "AzureCustomCloud",
+        };
+        sandbox.stub(TelemetryClient, "sendEvent").returns();
+    });
+    afterEach(() => {
+        sandbox.restore();
+    });
+    it("ApiServerItem loadmorechild return login", async () => {
+        sandbox.stub(AzureDataSessionProviderHelper, "getSessionProvider").returns(sessionProvider);
+        const node: ApiServerItem = new ApiServerItem(new DataPlanAccountManagerTreeItem(sessionProvider), subContext);
+        const res = await node.loadMoreChildrenImpl(true, {} as IActionContext);
+        assert.equal(res.length, 1);
+        assert.equal(res[0].commandId, "azure-api-center.apiCenterWorkspace.signInToDataPlane");
+    });
+    it("ApiServerItem loadmorechild return item", async () => {
+        sandbox.stub(AzureDataSessionProviderHelper, "getSessionProvider").returns(sessionProvider);
+        let autSession: AzureAuthenticationSession = {
+            id: 'test123', accessToken: 'fake_token', account: { id: 'fake_id', label: 'fake_label' }, scopes: [], tenantId: 'fake_id'
+        };
+        sessionProvider.getAuthSession = async () => { return { succeeded: true, result: autSession }; };
+        const node: ApiServerItem = new ApiServerItem(new DataPlanAccountManagerTreeItem(sessionProvider), subContext);
+        const res = await node.loadMoreChildrenImpl(true, {} as IActionContext);
+        assert.equal(res.length, 1);
+        console.log(res[0].contextValue, "azureApiCenterApis");
+    });
+});

--- a/src/test/unit/utils/telemetryUtils.test.ts
+++ b/src/test/unit/utils/telemetryUtils.test.ts
@@ -39,6 +39,7 @@ describe("telemetryUtils", () => {
     it("set Azure Resource dataplane info", () => {
         const mockSubscriptionContext = {
             subscriptionPath: "fakePath",
+            tenantId: "fakeTenantId",
         };
         const mockItem = new MockAzExtTreeItem(mockSubscriptionContext as ISubscriptionContext);
 
@@ -47,6 +48,7 @@ describe("telemetryUtils", () => {
         TelemetryUtils.setAzureResourcesInfo(properties, mockItem);
 
         assert.strictEqual(properties["dataPlaneRuntimeUrl"], "fakePath");
+        assert.strictEqual(properties["dataPlaneTenant"], "fakeTenantId");
         assert.strictEqual(properties["resourceName"], "mockLabel");
     });
 });

--- a/src/test/unit/utils/telemetryUtils.test.ts
+++ b/src/test/unit/utils/telemetryUtils.test.ts
@@ -38,7 +38,6 @@ describe("telemetryUtils", () => {
     });
     it("set Azure Resource dataplane info", () => {
         const mockSubscriptionContext = {
-            subscriptionId: "",
             subscriptionPath: "fakePath",
         };
         const mockItem = new MockAzExtTreeItem(mockSubscriptionContext as ISubscriptionContext);
@@ -47,7 +46,7 @@ describe("telemetryUtils", () => {
 
         TelemetryUtils.setAzureResourcesInfo(properties, mockItem);
 
-        assert.strictEqual(properties["subscriptionPath"], "fakePath");
+        assert.strictEqual(properties["dataPlaneRuntimeUrl"], "fakePath");
         assert.strictEqual(properties["resourceName"], "mockLabel");
     });
 });

--- a/src/test/unit/utils/telemetryUtils.test.ts
+++ b/src/test/unit/utils/telemetryUtils.test.ts
@@ -40,6 +40,7 @@ describe("telemetryUtils", () => {
         const mockSubscriptionContext = {
             subscriptionPath: "fakePath",
             tenantId: "fakeTenantId",
+            userId: "fakeClientId",
         };
         const mockItem = new MockAzExtTreeItem(mockSubscriptionContext as ISubscriptionContext);
 
@@ -48,7 +49,8 @@ describe("telemetryUtils", () => {
         TelemetryUtils.setAzureResourcesInfo(properties, mockItem);
 
         assert.strictEqual(properties["dataPlaneRuntimeUrl"], "fakePath");
-        assert.strictEqual(properties["dataPlaneTenant"], "fakeTenantId");
+        assert.strictEqual(properties["dataPlaneTenantId"], "fakeTenantId");
+        assert.strictEqual(properties["dataPlaneClientId"], "fakeClientId");
         assert.strictEqual(properties["resourceName"], "mockLabel");
     });
 });

--- a/src/test/unit/utils/telemetryUtils.test.ts
+++ b/src/test/unit/utils/telemetryUtils.test.ts
@@ -36,4 +36,18 @@ describe("telemetryUtils", () => {
         assert.strictEqual(properties["subscriptionId"], "mockSubscriptionId");
         assert.strictEqual(properties["resourceName"], "mockLabel");
     });
+    it("set Azure Resource dataplane info", () => {
+        const mockSubscriptionContext = {
+            subscriptionId: "",
+            subscriptionPath: "fakePath",
+        };
+        const mockItem = new MockAzExtTreeItem(mockSubscriptionContext as ISubscriptionContext);
+
+        const properties: { [key: string]: string; } = {};
+
+        TelemetryUtils.setAzureResourcesInfo(properties, mockItem);
+
+        assert.strictEqual(properties["subscriptionPath"], "fakePath");
+        assert.strictEqual(properties["resourceName"], "mockLabel");
+    });
 });

--- a/src/tree/DataPlaneAccount.ts
+++ b/src/tree/DataPlaneAccount.ts
@@ -7,9 +7,12 @@ import { ApiCenterApisDataplane } from "../azure/ApiCenterDefines/ApiCenterApi";
 import { AzureDataSessionProvider } from "../azure/azureLogin/authTypes";
 import { AzureAuth } from "../azure/azureLogin/azureAuth";
 import { AzureDataSessionProviderHelper, generateScopes } from "../azure/azureLogin/dataSessionProvider";
+import { TelemetryClient } from "../common/telemetryClient";
+import { TelemetryEvent } from "../common/telemetryEvent";
 import { ext } from "../extensionVariables";
 import { UiStrings } from "../uiStrings";
 import { GeneralUtils } from "../utils/generalUtils";
+import { TelemetryUtils } from "../utils/telemetryUtils";
 import { treeUtils } from "../utils/treeUtils";
 import { ApisTreeItem } from "./ApisTreeItem";
 export function createAzureDataAccountTreeItem(
@@ -59,6 +62,9 @@ export class ApiServerItem extends AzExtParentTreeItem {
     public readonly apisTreeItem: ApisTreeItem;
     public async loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
         let scopes = generateScopes(this.subscriptionContext.userId, this.subscriptionContext!.tenantId!);
+        const properties: { [key: string]: string; } = {};
+        TelemetryUtils.setAzureResourcesInfo(properties, this);
+        TelemetryClient.sendEvent(TelemetryEvent.treeviewListDataPlane, properties);
         const authSession = await AzureDataSessionProviderHelper.getSessionProvider().getAuthSession(scopes);
         if (GeneralUtils.failed(authSession)) {
             return [

--- a/src/utils/telemetryUtils.ts
+++ b/src/utils/telemetryUtils.ts
@@ -11,9 +11,10 @@ export namespace TelemetryUtils {
                 properties[TelemetryProperties.subscriptionId] = arg.subscription.subscriptionId;
             }
             // data plane has no subscriptionId but subscriptionPath.
-            else if (arg.subscription.subscriptionPath && arg.subscription.tenantId) {
+            else if (arg.subscription.subscriptionPath && arg.subscription.tenantId && arg.subscription.userId) {
                 properties[TelemetryProperties.dataPlaneRuntimeUrl] = arg.subscription.subscriptionPath;
-                properties[TelemetryProperties.dataPlaneTenant] = arg.subscription.tenantId;
+                properties[TelemetryProperties.dataPlaneTenantId] = arg.subscription.tenantId;
+                properties[TelemetryProperties.dataPlaneClientId] = arg.subscription.userId;
             }
             if (arg.label) {
                 properties[TelemetryProperties.resourceName] = arg.label;

--- a/src/utils/telemetryUtils.ts
+++ b/src/utils/telemetryUtils.ts
@@ -11,8 +11,9 @@ export namespace TelemetryUtils {
                 properties[TelemetryProperties.subscriptionId] = arg.subscription.subscriptionId;
             }
             // data plane has no subscriptionId but subscriptionPath.
-            else if (arg.subscription.subscriptionPath) {
+            else if (arg.subscription.subscriptionPath && arg.subscription.tenantId) {
                 properties[TelemetryProperties.dataPlaneRuntimeUrl] = arg.subscription.subscriptionPath;
+                properties[TelemetryProperties.dataPlaneTenant] = arg.subscription.tenantId;
             }
             if (arg.label) {
                 properties[TelemetryProperties.resourceName] = arg.label;

--- a/src/utils/telemetryUtils.ts
+++ b/src/utils/telemetryUtils.ts
@@ -10,6 +10,10 @@ export namespace TelemetryUtils {
             if (arg.subscription.subscriptionId) {
                 properties[TelemetryProperties.subscriptionId] = arg.subscription.subscriptionId;
             }
+            // data plane has no subscriptionId but subscriptionPath.
+            else if (arg.subscription.subscriptionPath) {
+                properties[TelemetryProperties.dataPlaneRuntimeUrl] = arg.subscription.subscriptionPath;
+            }
             if (arg.label) {
                 properties[TelemetryProperties.resourceName] = arg.label;
             }


### PR DESCRIPTION
For data plane, telemetry properties contains `runtime url`, `client id` and `tenant id`.
Events:
- Connect to an API Center [command]
- Connect to an API Center [DeepLink]
- Connect to an API Center [ui]
- Search APIs
- Remove DataPlaneApis
- Sign into Azure
- Export API spec
- Generate API Client
- Open API Doc
- Generate Markdown