### PR TITLE
Disable scheduled run for CLI weekly test

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,8 +1,8 @@
 name: CLI weekly live test
 
 on:
-  schedule:
-    - cron: "0 18 * * 0"
+#  schedule:
+#    - cron: "0 18 * * 0"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
ARM always use the latest API version to delete the resources. However, the latest API version of APIC is registered in ARM manifest but haven't finished rolling out. The test cases and other similar cleanup jobs cannot delete the created APIC resources after test finished. Disable the scheduled run to avoid left too many unused resources in our subscription.