### PR TITLE
fix: Enhance error handling in ProfilesTreeItem

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Follow the official documents to install the required softwares:
 ### Build the project
 
 1. Clone this repo locally. (`git clone https://github.com/Microsoft/vscode-azureapicenter.git`)
-1. Open a terminal and build locally. (`npm install && npm run package`)
+1. Open a terminal and build locally. (`npm install && npm run watch`)
 
 ### Debug the project
 

--- a/src/test/unit/tree/rules/ProfilesTreeItem.test.ts
+++ b/src/test/unit/tree/rules/ProfilesTreeItem.test.ts
@@ -60,4 +60,14 @@ describe('ProfilesTreeItem', () => {
     it('should indicate no more children', () => {
         assert.strictEqual(profilesTreeItem.hasMoreChildrenImpl(), false);
     });
+
+    it('should handle no analysis configs gracefully', async () => {
+        const apiCenterServiceStub = sandbox.stub(ApiCenterService.prototype, 'getApiCenterAnalyzerConfigs').resolves({ value: [] });
+        sandbox.stub(profilesTreeItem, 'createTreeItemsWithErrorHandling').resolves([]);
+
+        const children = await profilesTreeItem.loadMoreChildrenImpl(false, <IActionContext>{});
+
+        assert(apiCenterServiceStub.calledOnce);
+        assert.strictEqual(children.length, 0);
+    });
 });

--- a/src/tree/rules/ProfilesTreeItem.ts
+++ b/src/tree/rules/ProfilesTreeItem.ts
@@ -28,7 +28,8 @@ export class ProfilesTreeItem extends AzExtParentTreeItem {
         const resourceGroupName = getResourceGroupFromId(this.apiCenter.id);
         const apiCenterService = new ApiCenterService(this.parent?.subscription!, resourceGroupName, this.apiCenter.name);
 
-        const analyzerConfigs = (await apiCenterService.getApiCenterAnalyzerConfigs()).value;
+        // Fetch analyzer configurations, default to an empty array if none are found
+        const analyzerConfigs = (await apiCenterService.getApiCenterAnalyzerConfigs())?.value || [];
 
         return await this.createTreeItemsWithErrorHandling(
             analyzerConfigs,


### PR DESCRIPTION
# Problem
Some API Centers (APICs) may not have an analysis profile. This can happen for a few reasons:

- The APIC was created before we started scaffolding a default ruleset.
- The user accidentally deleted the configuration or ruleset.

To address this, we need to account for APICs without an analysis profile. Currently, when an APIC lacks a profile, we encounter an error that is not ideal.

<img src="https://github.com/user-attachments/assets/b8eed791-0e8e-42e2-ade5-b7a03d16823f" width=40% height=40%>

# Solution
Handling this case more gracefully by defaulting to an empty array if no analyzer configurations are found.

# Bonus
While I was trying to run the project by following the `README`, it did not work due to `npm run package` command not being designed for debugging, but rather for packaging the extension. I edited the instructions to se `npm run watch`