### PR TITLE
fix: use npm install --ignore-scripts in CD and CI lint to avoid node-gyp hang

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build visx
         run: |
-          npm install
+          npm install --ignore-scripts
           if [ "${{ github.event.inputs.preview }}" == "true" ]; then
             npx @vscode/vsce package --no-dependencies --pre-release --githubBranch ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
                   node-version: lts/*
             - name: Setup project
               run: |
-                  npm install
+                  npm install --ignore-scripts
                   npm run package
             - name: Check lint
               run: |


### PR DESCRIPTION
## Problem
The CD `Build visx` job hangs forever on `npm install` and is killed at the 6h timeout (orphaned `python`/`MainThread` processes confirm a node-gyp native rebuild). The CI `lint` job has the same bare `npm install` and the same hang. Last green CI was Apr 7; everything since hangs after `node-version: lts/*` advanced to a newer Node, forcing a native module rebuild that hangs on the runner.

## Fix
Use `npm install --ignore-scripts` in CD `Build visx` and CI `lint` — matching the `unit-test` job, which already uses it and is the only job that still completes. The vsix build (webpack + `vsce package --no-dependencies`) and lint do not need native modules compiled.

## Validation
- `npm run package` (production webpack build) succeeds locally with exit 0.
- `unit-test` already proves the project builds/tests with `--ignore-scripts`.