### PR TITLE
Fix command injection in Detect Breaking Change (Optic diff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ templates/openapi3
 
 # temp file for test plan synchrization
 testplan.json
+/.vs

--- a/package.json
+++ b/package.json
@@ -33,6 +33,12 @@
   ],
   "main": "./dist/extension.js",
   "l10n": "l10n",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "%azure-api-center.capabilities.untrustedWorkspaces.description%"
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,4 +1,5 @@
 {
+    "azure-api-center.capabilities.untrustedWorkspaces.description": "Commands that execute local tooling, such as Detect Breaking Change, are disabled in untrusted workspaces.",
     "azure-api-center.commands.selectSubscriptions.title": "Select Subscriptions...",
     "azure-api-center.commands.apiCenterTreeView.refresh.title": "Refresh",
     "azure-api-center.commands.open-api-docs.title": "Open API Documentation",

--- a/src/commands/detectBreakingChange.ts
+++ b/src/commands/detectBreakingChange.ts
@@ -18,6 +18,10 @@ export async function detectBreakingChange(context: IActionContext) {
         throw new Error(UiStrings.NoFolderOpened);
     }
 
+    if (!vscode.workspace.isTrusted) {
+        throw new Error(UiStrings.WorkspaceNotTrusted);
+    }
+
     const nodeVersion = await checkNodeVersion();
     if (!nodeVersion) {
         throw new Error(UiStrings.NoNodeInstalled);

--- a/src/uiStrings.ts
+++ b/src/uiStrings.ts
@@ -71,6 +71,7 @@ export class UiStrings {
     static readonly ApiVersionDefinitionsTreeItemChildTypeLabel = vscode.l10n.t("API Definition");
     static readonly NoFolderOpened = vscode.l10n.t("No folder is opened. Please open a folder to use this feature.");
     static readonly NoNodeInstalled = vscode.l10n.t("Node.js is not installed. Please install Node.js to use this feature.");
+    static readonly WorkspaceNotTrusted = vscode.l10n.t("This feature is disabled in untrusted workspaces. Please trust this workspace to use it.");
     static readonly SelectFirstApiSpecification = vscode.l10n.t("Select first API specification document");
     static readonly SelectSecondApiSpecification = vscode.l10n.t("Select second API specification document");
     static readonly SelectApiSpecification = vscode.l10n.t("Select API specification document");

--- a/src/utils/opticUtils.ts
+++ b/src/utils/opticUtils.ts
@@ -14,7 +14,17 @@ export async function opticDiff(filePath1: string, filePath2: string) {
         vscode.TaskScope.Workspace,
         UiStrings.OpticTaskName,
         UiStrings.OpticTaskSource,
-        new vscode.ShellExecution(`npx -y @useoptic/optic@0.54.12 diff '${filePath1}' '${filePath2}' --check`),
+        new vscode.ShellExecution(
+            "npx",
+            [
+                "-y",
+                "@useoptic/optic@0.54.12",
+                "diff",
+                { value: filePath1, quoting: vscode.ShellQuoting.Strong },
+                { value: filePath2, quoting: vscode.ShellQuoting.Strong },
+                "--check",
+            ],
+        ),
         "$optic"
     );
 


### PR DESCRIPTION
## Summary
Fixes a command injection vulnerability in the **Detect Breaking Change** feature. File paths were interpolated directly into a shell command string passed to `vscode.ShellExecution`, allowing a maliciously named file (e.g. `openapi'$(...)'.yaml`) to break out and execute arbitrary shell commands.

## Changes
- **`src/utils/opticUtils.ts`**: Replace the interpolated shell string with a `ShellExecution` argument array, passing each file path as a strongly-quoted argument (`vscode.ShellQuoting.Strong`). VS Code now escapes paths correctly so they can no longer break out into command substitution.
- **`package.json` / `package.nls.json`**: Declare `capabilities.untrustedWorkspaces` (limited) as defense-in-depth.
- **`src/commands/detectBreakingChange.ts` / `src/uiStrings.ts`**: Add a workspace-trust guard that disables the command in untrusted workspaces.

## Testing
- `tsc` / lint pass (lint-staged ran on commit).
- Verified no compile errors in changed files.