### PR TITLE
fix: bundle a single copy of @microsoft/vscode-azext-utils to fix activation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
               run: |
                   npm install --ignore-scripts
                   npm run package
+            - name: Verify bundle (single azext-utils instance)
+              run: |
+                  npm run verify-bundle
             - name: Check lint
               run: |
                   npm run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 > Note: This changelog only includes the changes for the stable versions of Azure API Center for Visual Studio Code. For the changelog of pre-released versions, please refer to the [Pre-release Changelog of Azure API Center for Visual Studio Code](https://github.com/microsoft/vscode-azureapicenter/blob/main/PRERELEASE.md).
 
+## 1.3.5
+* **Fix activation regression on load**: Bundle a single copy of `@microsoft/vscode-azext-utils` to avoid a webpack dual-package hazard that left the API Center tree views with "no data provider" and unregistered commands.
+
 ## 1.3.0
 * **'Edit API Specification Document' Command**: Added a command to edit and upload API spec.
 * **'Create new integration with Azure API Management' Command**: Added a command to sync APIs from APIM, also a new 'Integrations' tree node to list all the integrations.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "apidev",
   "displayName": "Azure API Center",
   "description": "Build, discover, and consume APIs.",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "icon": "media/api-center-icon.png",
   "license": "MIT",
   "engines": {
@@ -718,6 +718,7 @@
     "compile": "webpack",
     "watch": "webpack --watch",
     "package": "webpack --mode production --devtool hidden-source-map",
+    "verify-bundle": "node scripts/verify-bundle.js",
     "compile-tests": "tsc -p . --outDir out && copyfiles -u 1 \"src/test/resources/**/*\" out/",
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",

--- a/scripts/verify-bundle.js
+++ b/scripts/verify-bundle.js
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+
+const fs = require("fs");
+const path = require("path");
+
+const bundlePath = path.join(__dirname, "..", "dist", "extension.js");
+const MARKER =
+    '"registerUIExtensionVariables" must be called before using the @microsoft/vscode-azext-utils package';
+
+if (!fs.existsSync(bundlePath)) {
+    console.error(
+        `verify-bundle: bundle not found at ${bundlePath}. Run "npm run package" first.`
+    );
+    process.exit(1);
+}
+
+const bundle = fs.readFileSync(bundlePath, "utf8");
+const occurrences = bundle.split(MARKER).length - 1;
+
+if (occurrences > 1) {
+    console.error(
+        `verify-bundle: FAILED. Found ${occurrences} copies of @microsoft/vscode-azext-utils ` +
+            `in dist/extension.js (dual-package hazard). Expected at most 1.\n` +
+            `Check resolve.conditionNames in webpack.config.js.`
+    );
+    process.exit(1);
+}
+
+console.log(
+    `verify-bundle: OK. Single @microsoft/vscode-azext-utils instance in the bundle (markers found: ${occurrences}).`
+);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,14 @@ const extensionConfig = {
     resolve: {
         // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
         extensions: [".ts", ".js"],
+        // Force a single (CommonJS) copy of dual-published (ESM+CJS) packages.
+        // Packages like @microsoft/vscode-azext-* ship both an "import" (ESM) and
+        // "require" (CJS) build via the package "exports" field. Without pinning the
+        // condition, webpack can bundle BOTH builds, producing two instances of a
+        // module's singletons (e.g. the azext-utils `ext`). That breaks
+        // registerUIExtensionVariables at runtime ("must be called before using the
+        // @microsoft/vscode-azext-utils package"). Preferring "require" keeps one copy.
+        conditionNames: ["require", "node", "default"],
     },
     module: {
         rules: [


### PR DESCRIPTION
## Summary

Follow-up fix for the Node 24 work in #410 (v1.3.4). After upgrading to `@microsoft/vscode-azext-utils@4`, the extension failed to activate at runtime: both tree views showed **"There is no data provider registered that can provide view data"** and commands like `azure-api-center.apiCenterTreeView.refresh` were reported as **"command not found"**.

## Root cause

`@microsoft/vscode-azext-utils@4` ships **both** an ESM and a CJS build and exposes them through its `exports` field (`import` → esm, `require` → cjs). Webpack bundled **both** copies, producing **two** instances of the module-level `ext` singleton (`UninitializedExtensionVariables`).

`registerAzureUtilsExtensionVariables(ext)` initializes only **one** of the two copies, while the extension's tree items import the **other**, still-uninitialized copy. Accessing it during `activate()` throws:

> "registerUIExtensionVariables" must be called before using the @microsoft/vscode-azext-utils package

Because the error is thrown inside `activate()`, VS Code disposes all subscriptions — which is why **both** tree views lose their data providers **and** every command becomes unregistered.

## Fix

Add `resolve.conditionNames: ["require", "node", "default"]` to [webpack.config.js](webpack.config.js). This forces webpack to resolve a single (CJS) copy of the package, collapsing the duplicated singleton back to one instance.

## Regression guard

A standard unit test cannot catch this — it only manifests in the webpack bundle, not the `tsc` test build (which uses Node resolution and already collapses to one copy). To prevent recurrence:

- Added [scripts/verify-bundle.js](scripts/verify-bundle.js) (`npm run verify-bundle`), which fails if `dist/extension.js` ever contains more than one copy of the azext-utils singleton.
- Wired it into the CI `lint` job, right after `npm run package`, so every PR that rebuilds the production bundle is checked.

## Testing

- `npm run package` + `npm run verify-bundle` → single instance confirmed (markers: 1, was 2 before the fix).
- Built a local VSIX and verified activation: both tree views load and commands work.

## Notes

- Bumps version to **1.3.5** (1.3.4 shipped the regression).
